### PR TITLE
Fix plays since date issue

### DIFF
--- a/lastfm-card.html
+++ b/lastfm-card.html
@@ -46,7 +46,7 @@ Element that provide basic last.fm card containing info for a given user.
             <strong>plays</strong>
           </p>
 
-          <p>since {{info.user.registered['#text'] | dateConverter}}</p>
+          <p>since {{info.user.registered.unixtime | dateConverter}}</p>
         </section>
       </template>
       <template if="{{recentTracks}}">
@@ -158,7 +158,7 @@ Element that provide basic last.fm card containing info for a given user.
        */
       dateConverter: function(value) {
         if(typeof value !== 'undefined') {
-          var d = new Date(value);
+          var d = new Date(value*1000);
           return d.toDateString().substr(4);
         }
       }


### PR DESCRIPTION
Fixes #2 by using the `unixtime` attribute to generate the Date object. (See [user.getInfo on Last.FM's API docs](http://www.last.fm/api/show/user.getInfo).)

Working again:
![date-fixed](https://cloud.githubusercontent.com/assets/1934719/5604569/c81ec03a-9381-11e4-8789-e55c07335abd.PNG)
